### PR TITLE
use formula macro for statsmodels v0.2.4 compatibility

### DIFF
--- a/src/data/types.jl
+++ b/src/data/types.jl
@@ -23,7 +23,7 @@ function Microdata(
     )
 
     input    = reduce((x, y) -> x * " + " * y[2], "", kwargs)
-    formula  = Formula(nothing, parse(input))
+    formula  = @eval @formula $nothing ~ $(parse(input))
     terms    = Terms(formula)
     msng     = BitVector(completecases(df[:, terms.eterms]))
     msng    .= msng .* (.!iszero.(weights)) .* BitVector(subset)


### PR DESCRIPTION
StatsModels v0.2.4 moves parsing of formula expressions into the `@formula` macro.  As a result, calling the `Formula` constructor directly is discouraged since it doesn't expand things like `*`.  This change doens't affect the tests for this package but I've updated it nevertheless since it could produce unexpected behavior for users.  You might consider adding tests for more complicated formulae (at least testing things like `~ 1+a*b`).